### PR TITLE
put explicit initializers into extensions to keep default synthesized initializers

### DIFF
--- a/Sources/SwiftRant/AvatarCustomization.swift
+++ b/Sources/SwiftRant/AvatarCustomization.swift
@@ -186,20 +186,6 @@ public struct AvatarCustomizationResults: Decodable {
             case subType = "sub_type"
             case forGender = "for_gender"
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            do {
-                id = try values.decode(String.self, forKey: .id)
-            } catch {
-                id = try String(values.decode(Int.self, forKey: .id))
-            }
-            
-            label = try values.decode(String.self, forKey: .label)
-            subType = try values.decodeIfPresent(Int.self, forKey: .subType)
-            forGender = try values.decodeIfPresent(String.self, forKey: .forGender)
-        }
     }
     
     /// A model representing an avatar customization option.
@@ -227,16 +213,6 @@ public struct AvatarCustomizationResults: Decodable {
             case requiredPoints = "points"
             case isSelected = "selected"
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            backgroundColor = try values.decodeIfPresent(String.self, forKey: .backgroundColor)
-            id = try values.decodeIfPresent(String.self, forKey: .id)
-            image = try values.decode(AvatarCustomizationImage.self, forKey: .image)
-            requiredPoints = try values.decodeIfPresent(Int.self, forKey: .requiredPoints)
-            isSelected = try values.decodeIfPresent(Bool.self, forKey: .isSelected)
-        }
     }
     
     /// The customization options given for the requested type.
@@ -254,7 +230,9 @@ public struct AvatarCustomizationResults: Decodable {
         case userInfo = "me"
         case types = "options"
     }
-    
+}
+
+extension AvatarCustomizationResults {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -262,5 +240,33 @@ public struct AvatarCustomizationResults: Decodable {
         
         userInfo = try values.decode(AvatarCustomizationCurrentUserInfo.self, forKey: .userInfo)
         types = try values.decodeIfPresent([AvatarCustomizationType].self, forKey: .types)
+    }
+}
+
+extension AvatarCustomizationResults.AvatarCustomizationType {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        do {
+            id = try values.decode(String.self, forKey: .id)
+        } catch {
+            id = try String(values.decode(Int.self, forKey: .id))
+        }
+        
+        label = try values.decode(String.self, forKey: .label)
+        subType = try values.decodeIfPresent(Int.self, forKey: .subType)
+        forGender = try values.decodeIfPresent(String.self, forKey: .forGender)
+    }
+}
+
+extension AvatarCustomizationResults.AvatarCustomizationOption {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        backgroundColor = try values.decodeIfPresent(String.self, forKey: .backgroundColor)
+        id = try values.decodeIfPresent(String.self, forKey: .id)
+        image = try values.decode(AvatarCustomizationResults.AvatarCustomizationImage.self, forKey: .image)
+        requiredPoints = try values.decodeIfPresent(Int.self, forKey: .requiredPoints)
+        isSelected = try values.decodeIfPresent(Bool.self, forKey: .isSelected)
     }
 }

--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -91,7 +91,9 @@ public struct Comment: Decodable, Identifiable {
             }
         }
     }
-    
+}
+
+extension Comment {
     public init(decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(Int.self, forKey: .id)

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -63,7 +63,9 @@ public struct Notifications: Decodable {
         case unread
         case usernameMap = "username_map"
     }
-    
+}
+
+extension Notifications {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -107,6 +109,18 @@ public struct Notification: Decodable, Equatable {
         case uid
     }
     
+    public static func == (lhs: Notification, rhs: Notification) -> Bool {
+        return
+            lhs.commentID == rhs.commentID &&
+            lhs.createdTime == rhs.createdTime &&
+            lhs.rantID == rhs.rantID &&
+            lhs.read == rhs.read &&
+            lhs.type == rhs.type &&
+            lhs.uid == rhs.uid
+    }
+}
+
+extension Notification {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -116,16 +130,6 @@ public struct Notification: Decodable, Equatable {
         read = try values.decode(Int.self, forKey: .read)
         type = try values.decode(NotificationType.self, forKey: .type)
         uid = try values.decode(Int.self, forKey: .uid)
-    }
-    
-    public static func == (lhs: Notification, rhs: Notification) -> Bool {
-        return
-            lhs.commentID == rhs.commentID &&
-            lhs.createdTime == rhs.createdTime &&
-            lhs.rantID == rhs.rantID &&
-            lhs.read == rhs.read &&
-            lhs.type == rhs.type &&
-            lhs.uid == rhs.uid
     }
 }
 

--- a/Sources/SwiftRant/Profile.swift
+++ b/Sources/SwiftRant/Profile.swift
@@ -44,25 +44,6 @@ public struct Profile: Decodable {
                  favorites,
                  viewed
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            rants = try values.decode([RantInFeed].self, forKey: .rants)
-            upvoted = try values.decode([RantInFeed].self, forKey: .upvoted)
-            comments = try values.decode([Comment].self, forKey: .comments)
-            
-            do {
-                favorites = try values.decode([RantInFeed].self, forKey: .favorites)
-            } catch {
-                favorites = nil
-            }
-            
-            do {
-                viewed = try values.decode([RantInFeed].self, forKey: .viewed)
-            } catch {
-                viewed = nil
-            }
-        }
     }
     
     /// A structure representing the amount of content the user has created for every single type of content.
@@ -89,15 +70,6 @@ public struct Profile: Decodable {
                  comments,
                  favorites,
                  collabs
-        }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            rants = try values.decode(Int.self, forKey: .rants)
-            upvoted = try values.decode(Int.self, forKey: .upvoted)
-            comments = try values.decode(Int.self, forKey: .comments)
-            favorites = try values.decode(Int.self, forKey: .favorites)
-            collabs = try values.decode(Int.self, forKey: .collabs)
         }
     }
     
@@ -172,7 +144,9 @@ public struct Profile: Decodable {
              avatarSmall = "avatar_sm",
              isUserDPP = "dpp"
     }
-    
+}
+
+extension Profile {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -188,5 +162,37 @@ public struct Profile: Decodable {
         avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
         avatarSmall = try values.decode(Rant.UserAvatar.self, forKey: .avatarSmall)
         isUserDPP = try? values.decode(Int.self, forKey: .isUserDPP)
+    }
+}
+
+extension Profile.InnerUserContent {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        rants = try values.decode([RantInFeed].self, forKey: .rants)
+        upvoted = try values.decode([RantInFeed].self, forKey: .upvoted)
+        comments = try values.decode([Comment].self, forKey: .comments)
+        
+        do {
+            favorites = try values.decode([RantInFeed].self, forKey: .favorites)
+        } catch {
+            favorites = nil
+        }
+        
+        do {
+            viewed = try values.decode([RantInFeed].self, forKey: .viewed)
+        } catch {
+            viewed = nil
+        }
+    }
+}
+
+extension Profile.UserCounts {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        rants = try values.decode(Int.self, forKey: .rants)
+        upvoted = try values.decode(Int.self, forKey: .upvoted)
+        comments = try values.decode(Int.self, forKey: .comments)
+        favorites = try values.decode(Int.self, forKey: .favorites)
+        collabs = try values.decode(Int.self, forKey: .collabs)
     }
 }

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -67,24 +67,6 @@ public struct Rant: Decodable, Identifiable {
                  start,
                  end
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            type = try values.decode(String.self, forKey: .type)
-            
-            do {
-                url = try values.decode(String.self, forKey: .url)
-            } catch {
-                url = try String(values.decode(Int.self, forKey: .url))
-            }
-            
-            //url = try values.decodeIfPresent(String.self, forKey: .url) ?? String(values.decode(Int.self, forKey: .url))
-            shortURL = try values.decodeIfPresent(String.self, forKey: .shortURL)
-            title = try values.decode(String.self, forKey: .title)
-            start = try values.decodeIfPresent(Int.self, forKey: .start)
-            end = try values.decodeIfPresent(Int.self, forKey: .end)
-        }
     }
 
     /// Holds information about attached images in rants and comments.
@@ -113,13 +95,6 @@ public struct Rant: Decodable, Identifiable {
         enum CodingKeys: String, CodingKey {
             case backgroundColor = "b",
                  avatarImage = "i"
-        }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            backgroundColor = try values.decode(String.self, forKey: .backgroundColor)
-            avatarImage = try? values.decode(String.self, forKey: .avatarImage)
         }
     }
     
@@ -231,6 +206,32 @@ public struct Rant: Decodable, Identifiable {
              isUserDPP = "user_dpp"
     }
     
+    /// An enumeration that represents the types of posts that exist.
+    public enum RantType: Int {
+        /// Represents a rant post type.
+        case rant = 1
+        
+        /// Represents a collab post type.
+        case collab = 2
+        
+        /// Represents a meme post type.
+        case meme = 3
+        
+        /// Represents a question post type.
+        case question = 4
+        
+        /// Represents a devRant-related post type.
+        case devRant = 5
+        
+        /// Represents a random topic post type.
+        case random = 6
+        
+        /// Represents an undefined post type (not available anymore in the official client).
+        case undefined = 7
+    }
+}
+
+extension Rant {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -286,28 +287,33 @@ public struct Rant: Decodable, Identifiable {
             }
         }
     }
-    
-    /// An enumeration that represents the types of posts that exist.
-    public enum RantType: Int {
-        /// Represents a rant post type.
-        case rant = 1
+}
+
+extension Rant.Link {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
         
-        /// Represents a collab post type.
-        case collab = 2
+        type = try values.decode(String.self, forKey: .type)
         
-        /// Represents a meme post type.
-        case meme = 3
+        do {
+            url = try values.decode(String.self, forKey: .url)
+        } catch {
+            url = try String(values.decode(Int.self, forKey: .url))
+        }
         
-        /// Represents a question post type.
-        case question = 4
+        //url = try values.decodeIfPresent(String.self, forKey: .url) ?? String(values.decode(Int.self, forKey: .url))
+        shortURL = try values.decodeIfPresent(String.self, forKey: .shortURL)
+        title = try values.decode(String.self, forKey: .title)
+        start = try values.decodeIfPresent(Int.self, forKey: .start)
+        end = try values.decodeIfPresent(Int.self, forKey: .end)
+    }
+}
+
+extension Rant.UserAvatar {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
         
-        /// Represents a devRant-related post type.
-        case devRant = 5
-        
-        /// Represents a random topic post type.
-        case random = 6
-        
-        /// Represents an undefined post type (not available anymore in the official client).
-        case undefined = 7
+        backgroundColor = try values.decode(String.self, forKey: .backgroundColor)
+        avatarImage = try? values.decode(String.self, forKey: .avatarImage)
     }
 }

--- a/Sources/SwiftRant/RantFeed.swift
+++ b/Sources/SwiftRant/RantFeed.swift
@@ -23,13 +23,6 @@ public struct RantFeed: Decodable {
             case notificationState = "notif_state"
             case notificationToken = "notif_token"
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            notificationState = try values.decode(String.self, forKey: .notificationState)
-            notificationToken = try? values.decode(String.self, forKey: .notificationToken)
-        }
     }
     
     /// Contains the amount of unread notifications.
@@ -107,7 +100,9 @@ public struct RantFeed: Decodable {
         case unread
         case news
     }
-    
+}
+
+extension RantFeed {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -119,5 +114,14 @@ public struct RantFeed: Decodable {
         notifCount = try values.decode(Int.self, forKey: .notifCount)
         unread = try values.decode(Unread.self, forKey: .unread)
         news = try values.decodeIfPresent(News.self, forKey: .news)
+    }
+}
+
+extension RantFeed.Settings {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        notificationState = try values.decode(String.self, forKey: .notificationState)
+        notificationToken = try? values.decode(String.self, forKey: .notificationToken)
     }
 }

--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -93,7 +93,9 @@ public struct RantInFeed: Decodable, Identifiable {
              userAvatarLarge = "user_avatar_lg",
              isUserDPP = "user_dpp"
     }
-    
+}
+
+extension RantInFeed {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(Int.self, forKey: .id)

--- a/Sources/SwiftRant/RantInSubscribedFeed.swift
+++ b/Sources/SwiftRant/RantInSubscribedFeed.swift
@@ -126,13 +126,6 @@ public struct RantInSubscribedFeed: Decodable {
         
         /// The action the user performed.
         public let action: UserAction
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            userID = Int(try values.decode(String.self, forKey: .userID))!
-            action = UserAction(rawValue: try values.decode(String.self, forKey: .action))!
-        }
     }
     
     /// The rant's ID.
@@ -173,7 +166,9 @@ public struct RantInSubscribedFeed: Decodable {
         case rant
         case actions
     }
-    
+}
+
+extension RantInSubscribedFeed {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -201,5 +196,14 @@ public struct RantInSubscribedFeed: Decodable {
         isEdited = rantInFeedProperties["edited"]! as! Bool
         
         relatedUserActions = try values.decode([RelatedUserAction].self, forKey: .actions)
+    }
+}
+
+extension RantInSubscribedFeed.RelatedUserAction {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: RantInSubscribedFeed.RelatedUserAction.CodingKeys.self)
+        
+        userID = Int(try values.decode(String.self, forKey: .userID))!
+        action = RantInSubscribedFeed.RelatedUserAction.UserAction(rawValue: try values.decode(String.self, forKey: .action))!
     }
 }

--- a/Sources/SwiftRant/SubscribedFeed.swift
+++ b/Sources/SwiftRant/SubscribedFeed.swift
@@ -22,13 +22,6 @@ public struct SubscribedFeed: Decodable {
             case endCursor = "end_cursor"
             case hasNextPage = "has_next_page"
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            endCursor = try values.decode(String.self, forKey: .endCursor)
-            hasNextPage = try values.decode(Bool.self, forKey: .hasNextPage)
-        }
     }
     
     /// A structure representing the list of users the devRant API thinks it can recommend to the user.
@@ -44,22 +37,6 @@ public struct SubscribedFeed: Decodable {
         private enum CodingKeys: String, CodingKey {
             case items
             case hasNextPage = "has_next_page"
-        }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            let decodedItemsArray = try values.decode(Array<Any>.self, forKey: .items) as! Array<Dictionary<String, Int>>
-            
-            var tempUsers = [Int]()
-            
-            for item in decodedItemsArray {
-                tempUsers.append(item["uid"]!)
-            }
-            
-            users = tempUsers
-            
-            hasNextPage = try values.decode(Bool.self, forKey: .hasNextPage)
         }
     }
     
@@ -96,16 +73,6 @@ public struct SubscribedFeed: Decodable {
                 case avatar
                 case score
             }
-            
-            public init(from decoder: Decoder) throws {
-                let values = try decoder.container(keyedBy: CodingKeys.self)
-                
-                username = try values.decode(String.self, forKey: .username)
-                avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
-                score = try values.decode(Int.self, forKey: .score)
-                
-                userID = Int(values.codingPath[values.codingPath.endIndex - 1].stringValue)!
-            }
         }
         
         /// The array of the users.
@@ -124,19 +91,6 @@ public struct SubscribedFeed: Decodable {
                 return nil
             }
         }
-        
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
-            
-            var tempArray = [User]()
-            
-            for key in values.allKeys {
-                let decodedObject = try values.decode(User.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
-                tempArray.append(decodedObject)
-            }
-            
-            users = tempArray
-        }
     }
     
     /// The rants in the feed.
@@ -154,7 +108,9 @@ public struct SubscribedFeed: Decodable {
     private enum CodingKeys: String, CodingKey {
         case feed
     }
-    
+}
+
+extension SubscribedFeed {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -191,5 +147,59 @@ public struct SubscribedFeed: Decodable {
         let usernameMapData = try JSONSerialization.data(withJSONObject: usernameMapDict, options: [])
         
         usernameMap = try JSONDecoder().decode(UsernameMap.self, from: usernameMapData)
+    }
+}
+
+extension SubscribedFeed.PageInfo {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        endCursor = try values.decode(String.self, forKey: .endCursor)
+        hasNextPage = try values.decode(Bool.self, forKey: .hasNextPage)
+    }
+}
+
+extension SubscribedFeed.RecommendedUsers {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let decodedItemsArray = try values.decode(Array<Any>.self, forKey: .items) as! Array<Dictionary<String, Int>>
+        
+        var tempUsers = [Int]()
+        
+        for item in decodedItemsArray {
+            tempUsers.append(item["uid"]!)
+        }
+        
+        users = tempUsers
+        
+        hasNextPage = try values.decode(Bool.self, forKey: .hasNextPage)
+    }
+}
+
+extension SubscribedFeed.UsernameMap {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
+        
+        var tempArray = [User]()
+        
+        for key in values.allKeys {
+            let decodedObject = try values.decode(User.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
+            tempArray.append(decodedObject)
+        }
+        
+        users = tempArray
+    }
+}
+
+extension SubscribedFeed.UsernameMap.User {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        username = try values.decode(String.self, forKey: .username)
+        avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
+        score = try values.decode(Int.self, forKey: .score)
+        
+        userID = Int(values.codingPath[values.codingPath.endIndex - 1].stringValue)!
     }
 }

--- a/Sources/SwiftRant/UserCredentials.swift
+++ b/Sources/SwiftRant/UserCredentials.swift
@@ -31,15 +31,6 @@ public struct UserCredentials: Codable, Equatable {
             case userID = "user_id"
         }
         
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            
-            tokenID = try values.decode(Int.self, forKey: .tokenID)
-            tokenKey = try values.decode(String.self, forKey: .tokenKey)
-            expireTime = try values.decode(Int.self, forKey: .expireTime)
-            userID = try values.decode(Int.self, forKey: .userID)
-        }
-        
         public func encode(to encoder: Encoder) throws {
             var values = encoder.container(keyedBy: CodingKeys.self)
             
@@ -57,12 +48,6 @@ public struct UserCredentials: Codable, Equatable {
         case authToken = "auth_token"
     }
     
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        authToken = try values.decode(AuthToken.self, forKey: .authToken)
-    }
-    
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: CodingKeys.self)
         
@@ -74,5 +59,24 @@ public struct UserCredentials: Codable, Equatable {
             lhs.authToken.tokenID == rhs.authToken.tokenID &&
             lhs.authToken.tokenKey == rhs.authToken.tokenKey &&
             lhs.authToken.expireTime == rhs.authToken.expireTime
+    }
+}
+
+extension UserCredentials {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        authToken = try values.decode(AuthToken.self, forKey: .authToken)
+    }
+}
+
+extension UserCredentials.AuthToken {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        tokenID = try values.decode(Int.self, forKey: .tokenID)
+        tokenKey = try values.decode(String.self, forKey: .tokenKey)
+        expireTime = try values.decode(Int.self, forKey: .expireTime)
+        userID = try values.decode(Int.self, forKey: .userID)
     }
 }

--- a/Sources/SwiftRant/UsernameMap.swift
+++ b/Sources/SwiftRant/UsernameMap.swift
@@ -28,15 +28,6 @@ public extension Notifications {
                 case avatar
                 case name
             }
-            
-            public init(from decoder: Decoder) throws {
-                let values = try decoder.container(keyedBy: CodingKeys.self)
-                
-                avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
-                name = try values.decode(String.self, forKey: .name)
-                
-                uidForUsername = values.codingPath[values.codingPath.endIndex - 1].stringValue
-            }
         }
         
         /// The array holding the maps.
@@ -55,18 +46,31 @@ public extension Notifications {
                 return nil
             }
         }
+    }
+}
+
+extension Notifications.UsernameMapArray {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
         
-        public init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
-            
-            var tempArray = [UsernameMap]()
-            
-            for key in values.allKeys {
-                let decodedObject = try values.decode(UsernameMap.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
-                tempArray.append(decodedObject)
-            }
-            
-            array = tempArray
+        var tempArray = [UsernameMap]()
+        
+        for key in values.allKeys {
+            let decodedObject = try values.decode(UsernameMap.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
+            tempArray.append(decodedObject)
         }
+        
+        array = tempArray
+    }
+}
+
+extension Notifications.UsernameMapArray.UsernameMap {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
+        name = try values.decode(String.self, forKey: .name)
+        
+        uidForUsername = values.codingPath[values.codingPath.endIndex - 1].stringValue
     }
 }


### PR DESCRIPTION
Put the explicit initializers like `init(from decoder: Decoder)` into extensions of the structs, so that it doesn't prevent the generation of the default memberwise initializers.
The default initializers are needed to easily create instances of the models for the purpose of mock or example data (e.g. for preview Views in SwiftUI).