### PR TITLE
changed voteState from Int to enum

### DIFF
--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -37,7 +37,23 @@ public struct RantInFeed: Decodable, Identifiable {
     /// * `0` = Unvoted
     /// * `-1` = Downvote
     /// * `-2` = Voting disabled (the rant belongs to the user whose token was used to fetch the rant)
-    public var voteState: Int
+    public var voteStateRaw: Int
+    
+    public enum VoteState: Int {
+        case upvoted = 1
+        case unvoted = 0
+        case downvoted = -1
+        case unvotable = -2
+    }
+    
+    public var voteState: VoteState {
+        get {
+            return VoteState(rawValue: voteStateRaw) ?? .unvotable
+        }
+        set {
+            voteStateRaw = newValue.rawValue
+        }
+    }
     
     /// Whether or not the rant was edited in the past.
     public let isEdited: Bool
@@ -111,7 +127,7 @@ extension RantInFeed {
         
         commentCount = try values.decode(Int.self, forKey: .commentCount)
         tags = try values.decode([String].self, forKey: .tags)
-        voteState = try values.decode(Int.self, forKey: .voteState)
+        voteStateRaw = try values.decode(Int.self, forKey: .voteState)
         isEdited = try values.decode(Bool.self, forKey: .isEdited)
         link = try? values.decode(String.self, forKey: .link)
         collabType = try? values.decode(Int.self, forKey: .collabType)


### PR DESCRIPTION
Changed the type of `voteState` in `RantInFeed` from `Int` to an enum, so that the consumer can use descriptive enum cases instead of the numbers -2, -1, 0, 1.

This is a breaking change since I've changed the type of the variable and renamed the old one to `voteStateRaw`.
So, I suggest to bump the major version number, according to SEMVER.

Alternatively, if you are against a breaking change, I could introduce a new variable with the enum type instead.