### PR TITLE
added explicit public memberwise initializers

### DIFF
--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -70,7 +70,39 @@ public struct Comment: Decodable, Identifiable {
              attachedImage = "attached_image"
     }
     
-    public mutating func precalculateLinkRanges() {
+    public init(uuid: UUID = UUID(), id: Int, rantID: Int, body: String, score: Int, createdTime: Int, voteState: Int, links: [Rant.Link]?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, isUserDPP: Int?, attachedImage: Rant.AttachedImage?) {
+        self.uuid = uuid
+        self.id = id
+        self.rantID = rantID
+        self.body = body
+        self.score = score
+        self.createdTime = createdTime
+        self.voteState = voteState
+        self.links = links
+        self.userID = userID
+        self.username = username
+        self.userScore = userScore
+        self.userAvatar = userAvatar
+        self.isUserDPP = isUserDPP
+        self.attachedImage = attachedImage
+    }
+    
+    public init(decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(Int.self, forKey: .id)
+        rantID = try values.decode(Int.self, forKey: .rantID)
+        body = try values.decode(String.self, forKey: .body)
+        score = try values.decode(Int.self, forKey: .score)
+        createdTime = try values.decode(Int.self, forKey: .createdTime)
+        voteState = try values.decode(Int.self, forKey: .voteState)
+        links = try? values.decodeIfPresent([Rant.Link].self, forKey: .links)
+        userID = try values.decode(Int.self, forKey: .userID)
+        username = try values.decode(String.self, forKey: .username)
+        userScore = try values.decode(Int.self, forKey: .userScore)
+        userAvatar = try values.decode(Rant.UserAvatar.self, forKey: .userAvatar)
+        isUserDPP = try? values.decode(Int.self, forKey: .isUserDPP)
+        attachedImage = try? values.decode(Rant.AttachedImage.self, forKey: .attachedImage)
+        
         if links != nil {
             let stringAsData = body.data(using: .utf8)!
             
@@ -91,25 +123,8 @@ public struct Comment: Decodable, Identifiable {
             }
         }
     }
-}
-
-extension Comment {
-    public init(decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        id = try values.decode(Int.self, forKey: .id)
-        rantID = try values.decode(Int.self, forKey: .rantID)
-        body = try values.decode(String.self, forKey: .body)
-        score = try values.decode(Int.self, forKey: .score)
-        createdTime = try values.decode(Int.self, forKey: .createdTime)
-        voteState = try values.decode(Int.self, forKey: .voteState)
-        links = try? values.decodeIfPresent([Rant.Link].self, forKey: .links)
-        userID = try values.decode(Int.self, forKey: .userID)
-        username = try values.decode(String.self, forKey: .username)
-        userScore = try values.decode(Int.self, forKey: .userScore)
-        userAvatar = try values.decode(Rant.UserAvatar.self, forKey: .userAvatar)
-        isUserDPP = try? values.decode(Int.self, forKey: .isUserDPP)
-        attachedImage = try? values.decode(Rant.AttachedImage.self, forKey: .attachedImage)
-        
+    
+    public mutating func precalculateLinkRanges() {
         if links != nil {
             let stringAsData = body.data(using: .utf8)!
             

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -9,6 +9,10 @@ import Foundation
 
 struct NotificationFeed: Decodable {
     public let data: Notifications
+    
+    public init(data: Notifications) {
+        self.data = data
+    }
 }
 
 /// A model representing the notification data.
@@ -43,6 +47,15 @@ public struct Notifications: Decodable {
         
         /// The total amount of unread upvotes.
         public let upvotes: Int
+        
+        public init(all: Int, comments: Int, mentions: Int, subs: Int, total: Int, upvotes: Int) {
+            self.all = all
+            self.comments = comments
+            self.mentions = mentions
+            self.subs = subs
+            self.total = total
+            self.upvotes = upvotes
+        }
     }
     
     /// The server-side Unix timestamp at which the list of notifications were last checked.
@@ -63,18 +76,20 @@ public struct Notifications: Decodable {
         case unread
         case usernameMap = "username_map"
     }
-}
-
-extension Notifications {
+    
+    public init(checkTime: Int, items: [Notification], unread: Notifications.UnreadNotifications, usernameMap: Notifications.UsernameMapArray?) {
+        self.checkTime = checkTime
+        self.items = items
+        self.unread = unread
+        self.usernameMap = usernameMap
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
         checkTime = try values.decode(Int.self, forKey: .checkTime)
-        
         items = try values.decodeIfPresent([Notification].self, forKey: .items) ?? []
-        
         unread = try values.decode(UnreadNotifications.self, forKey: .unread)
-        
         usernameMap = try? values.decode(UsernameMapArray.self, forKey: .usernameMap)
     }
 }
@@ -118,9 +133,16 @@ public struct Notification: Decodable, Equatable {
             lhs.type == rhs.type &&
             lhs.uid == rhs.uid
     }
-}
-
-extension Notification {
+    
+    public init(commentID: Int?, createdTime: Int, rantID: Int, read: Int, type: NotificationType, uid: Int) {
+        self.commentID = commentID
+        self.createdTime = createdTime
+        self.rantID = rantID
+        self.read = read
+        self.type = type
+        self.uid = uid
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         

--- a/Sources/SwiftRant/Profile.swift
+++ b/Sources/SwiftRant/Profile.swift
@@ -17,6 +17,11 @@ public struct Profile: Decodable {
         
         /// How much content of every type made by the user exists on devRant.
         public let counts: UserCounts
+        
+        public init(content: Profile.InnerUserContent, counts: Profile.UserCounts) {
+            self.content = content
+            self.counts = counts
+        }
     }
     
     /// The actual content created by the user.
@@ -44,6 +49,33 @@ public struct Profile: Decodable {
                  favorites,
                  viewed
         }
+        
+        public init(rants: [RantInFeed], upvoted: [RantInFeed], comments: [Comment], favorites: [RantInFeed]? = nil, viewed: [RantInFeed]? = nil) {
+            self.rants = rants
+            self.upvoted = upvoted
+            self.comments = comments
+            self.favorites = favorites
+            self.viewed = viewed
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            rants = try values.decode([RantInFeed].self, forKey: .rants)
+            upvoted = try values.decode([RantInFeed].self, forKey: .upvoted)
+            comments = try values.decode([Comment].self, forKey: .comments)
+            
+            do {
+                favorites = try values.decode([RantInFeed].self, forKey: .favorites)
+            } catch {
+                favorites = nil
+            }
+            
+            do {
+                viewed = try values.decode([RantInFeed].self, forKey: .viewed)
+            } catch {
+                viewed = nil
+            }
+        }
     }
     
     /// A structure representing the amount of content the user has created for every single type of content.
@@ -70,6 +102,23 @@ public struct Profile: Decodable {
                  comments,
                  favorites,
                  collabs
+        }
+        
+        public init(rants: Int, upvoted: Int, comments: Int, favorites: Int, collabs: Int) {
+            self.rants = rants
+            self.upvoted = upvoted
+            self.comments = comments
+            self.favorites = favorites
+            self.collabs = collabs
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            rants = try values.decode(Int.self, forKey: .rants)
+            upvoted = try values.decode(Int.self, forKey: .upvoted)
+            comments = try values.decode(Int.self, forKey: .comments)
+            favorites = try values.decode(Int.self, forKey: .favorites)
+            collabs = try values.decode(Int.self, forKey: .collabs)
         }
     }
     
@@ -144,9 +193,22 @@ public struct Profile: Decodable {
              avatarSmall = "avatar_sm",
              isUserDPP = "dpp"
     }
-}
-
-extension Profile {
+    
+    public init(username: String, score: Int, about: String, location: String, createdTime: Int, skills: String, github: String, website: String?, content: Profile.OuterUserContent, avatar: Rant.UserAvatar, avatarSmall: Rant.UserAvatar, isUserDPP: Int?) {
+        self.username = username
+        self.score = score
+        self.about = about
+        self.location = location
+        self.createdTime = createdTime
+        self.skills = skills
+        self.github = github
+        self.website = website
+        self.content = content
+        self.avatar = avatar
+        self.avatarSmall = avatarSmall
+        self.isUserDPP = isUserDPP
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -162,37 +224,5 @@ extension Profile {
         avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
         avatarSmall = try values.decode(Rant.UserAvatar.self, forKey: .avatarSmall)
         isUserDPP = try? values.decode(Int.self, forKey: .isUserDPP)
-    }
-}
-
-extension Profile.InnerUserContent {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        rants = try values.decode([RantInFeed].self, forKey: .rants)
-        upvoted = try values.decode([RantInFeed].self, forKey: .upvoted)
-        comments = try values.decode([Comment].self, forKey: .comments)
-        
-        do {
-            favorites = try values.decode([RantInFeed].self, forKey: .favorites)
-        } catch {
-            favorites = nil
-        }
-        
-        do {
-            viewed = try values.decode([RantInFeed].self, forKey: .viewed)
-        } catch {
-            viewed = nil
-        }
-    }
-}
-
-extension Profile.UserCounts {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        rants = try values.decode(Int.self, forKey: .rants)
-        upvoted = try values.decode(Int.self, forKey: .upvoted)
-        comments = try values.decode(Int.self, forKey: .comments)
-        favorites = try values.decode(Int.self, forKey: .favorites)
-        collabs = try values.decode(Int.self, forKey: .collabs)
     }
 }

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -24,6 +24,13 @@ public struct Rant: Decodable, Identifiable {
         
         /// The week number for the weekly group rant.
         public let week: Int
+        
+        public init(date: String, height: Int, topic: String, week: Int) {
+            self.date = date
+            self.height = height
+            self.topic = topic
+            self.week = week
+        }
     }
 
     /// Holds information about links inside rants and comments.
@@ -67,6 +74,34 @@ public struct Rant: Decodable, Identifiable {
                  start,
                  end
         }
+        
+        public init(type: String, url: String, shortURL: String?, title: String, start: Int?, end: Int?, calculatedRange: NSRange? = nil) {
+            self.type = type
+            self.url = url
+            self.shortURL = shortURL
+            self.title = title
+            self.start = start
+            self.end = end
+            self.calculatedRange = calculatedRange
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            
+            type = try values.decode(String.self, forKey: .type)
+            
+            do {
+                url = try values.decode(String.self, forKey: .url)
+            } catch {
+                url = try String(values.decode(Int.self, forKey: .url))
+            }
+            
+            //url = try values.decodeIfPresent(String.self, forKey: .url) ?? String(values.decode(Int.self, forKey: .url))
+            shortURL = try values.decodeIfPresent(String.self, forKey: .shortURL)
+            title = try values.decode(String.self, forKey: .title)
+            start = try values.decodeIfPresent(Int.self, forKey: .start)
+            end = try values.decodeIfPresent(Int.self, forKey: .end)
+        }
     }
 
     /// Holds information about attached images in rants and comments.
@@ -81,6 +116,12 @@ public struct Rant: Decodable, Identifiable {
         
         /// The attached image's height.
         public let height: Int
+        
+        public init(url: String, width: Int, height: Int) {
+            self.url = url
+            self.width = width
+            self.height = height
+        }
     }
 
     /// Holds information about a user's avatar.
@@ -95,6 +136,18 @@ public struct Rant: Decodable, Identifiable {
         enum CodingKeys: String, CodingKey {
             case backgroundColor = "b",
                  avatarImage = "i"
+        }
+        
+        public init(backgroundColor: String, avatarImage: String?) {
+            self.backgroundColor = backgroundColor
+            self.avatarImage = avatarImage
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            
+            backgroundColor = try values.decode(String.self, forKey: .backgroundColor)
+            avatarImage = try? values.decode(String.self, forKey: .avatarImage)
         }
     }
     
@@ -229,9 +282,34 @@ public struct Rant: Decodable, Identifiable {
         /// Represents an undefined post type (not available anymore in the official client).
         case undefined = 7
     }
-}
-
-extension Rant {
+    
+    public init(weekly: Rant.Weekly?, id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: Int, isEdited: Bool, isFavorite: Int? = nil, link: String?, links: [Rant.Link]? = nil, collabTypeLong: String?, collabDescription: String?, collabTechStack: String?, collabTeamSize: String?, collabURL: String?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, userAvatarLarge: Rant.UserAvatar, isUserDPP: Int?) {
+        self.weekly = weekly
+        self.id = id
+        self.text = text
+        self.score = score
+        self.createdTime = createdTime
+        self.attachedImage = attachedImage
+        self.commentCount = commentCount
+        self.tags = tags
+        self.voteState = voteState
+        self.isEdited = isEdited
+        self.isFavorite = isFavorite
+        self.link = link
+        self.links = links
+        self.collabTypeLong = collabTypeLong
+        self.collabDescription = collabDescription
+        self.collabTechStack = collabTechStack
+        self.collabTeamSize = collabTeamSize
+        self.collabURL = collabURL
+        self.userID = userID
+        self.username = username
+        self.userScore = userScore
+        self.userAvatar = userAvatar
+        self.userAvatarLarge = userAvatarLarge
+        self.isUserDPP = isUserDPP
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -286,34 +364,5 @@ extension Rant {
                 }
             }
         }
-    }
-}
-
-extension Rant.Link {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        type = try values.decode(String.self, forKey: .type)
-        
-        do {
-            url = try values.decode(String.self, forKey: .url)
-        } catch {
-            url = try String(values.decode(Int.self, forKey: .url))
-        }
-        
-        //url = try values.decodeIfPresent(String.self, forKey: .url) ?? String(values.decode(Int.self, forKey: .url))
-        shortURL = try values.decodeIfPresent(String.self, forKey: .shortURL)
-        title = try values.decode(String.self, forKey: .title)
-        start = try values.decodeIfPresent(Int.self, forKey: .start)
-        end = try values.decodeIfPresent(Int.self, forKey: .end)
-    }
-}
-
-extension Rant.UserAvatar {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        backgroundColor = try values.decode(String.self, forKey: .backgroundColor)
-        avatarImage = try? values.decode(String.self, forKey: .avatarImage)
     }
 }

--- a/Sources/SwiftRant/RantFeed.swift
+++ b/Sources/SwiftRant/RantFeed.swift
@@ -23,6 +23,18 @@ public struct RantFeed: Decodable {
             case notificationState = "notif_state"
             case notificationToken = "notif_token"
         }
+        
+        public init(notificationState: String, notificationToken: String?) {
+            self.notificationState = notificationState
+            self.notificationToken = notificationToken
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            
+            notificationState = try values.decode(String.self, forKey: .notificationState)
+            notificationToken = try? values.decode(String.self, forKey: .notificationToken)
+        }
     }
     
     /// Contains the amount of unread notifications.
@@ -30,6 +42,10 @@ public struct RantFeed: Decodable {
         
         /// The total count of unread notifications.
         public let total: Int
+        
+        public init(total: Int) {
+            self.total = total
+        }
     }
     
     /// Contains information about news given in rant feeds.
@@ -56,6 +72,16 @@ public struct RantFeed: Decodable {
         
         /// The expected action that should take place when the news story is tapped/clicked on.
         public let action: RantFeedNewsAction
+        
+        public init(id: Int, type: String, headline: String, body: String, footer: String, height: Int, action: RantFeed.RantFeedNewsAction) {
+            self.id = id
+            self.type = type
+            self.headline = headline
+            self.body = body
+            self.footer = footer
+            self.height = height
+            self.action = action
+        }
     }
     
     /// Has all cases of actions for tapping on a news heading in the rant feed.
@@ -100,9 +126,18 @@ public struct RantFeed: Decodable {
         case unread
         case news
     }
-}
-
-extension RantFeed {
+    
+    public init(rants: [RantInFeed], settings: RantFeed.Settings, set: String, weeklyRantWeek: Int?, isUserDPP: Int, notifCount: Int, unread: RantFeed.Unread, news: RantFeed.News?) {
+        self.rants = rants
+        self.settings = settings
+        self.set = set
+        self.weeklyRantWeek = weeklyRantWeek
+        self.isUserDPP = isUserDPP
+        self.notifCount = notifCount
+        self.unread = unread
+        self.news = news
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -114,14 +149,5 @@ extension RantFeed {
         notifCount = try values.decode(Int.self, forKey: .notifCount)
         unread = try values.decode(Unread.self, forKey: .unread)
         news = try values.decodeIfPresent(News.self, forKey: .news)
-    }
-}
-
-extension RantFeed.Settings {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        notificationState = try values.decode(String.self, forKey: .notificationState)
-        notificationToken = try? values.decode(String.self, forKey: .notificationToken)
     }
 }

--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -109,9 +109,28 @@ public struct RantInFeed: Decodable, Identifiable {
              userAvatarLarge = "user_avatar_lg",
              isUserDPP = "user_dpp"
     }
-}
-
-extension RantInFeed {
+    
+    public init(id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: VoteState, isEdited: Bool, link: String?, collabType: Int?, collabTypeLong: String?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, userAvatarLarge: Rant.UserAvatar, isUserDPP: Int?) {
+        self.id = id
+        self.text = text
+        self.score = score
+        self.createdTime = createdTime
+        self.attachedImage = attachedImage
+        self.commentCount = commentCount
+        self.tags = tags
+        self.voteStateRaw = voteState.rawValue
+        self.isEdited = isEdited
+        self.link = link
+        self.collabType = collabType
+        self.collabTypeLong = collabTypeLong
+        self.userID = userID
+        self.username = username
+        self.userScore = userScore
+        self.userAvatar = userAvatar
+        self.userAvatarLarge = userAvatarLarge
+        self.isUserDPP = isUserDPP
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(Int.self, forKey: .id)

--- a/Sources/SwiftRant/RantInSubscribedFeed.swift
+++ b/Sources/SwiftRant/RantInSubscribedFeed.swift
@@ -126,6 +126,18 @@ public struct RantInSubscribedFeed: Decodable {
         
         /// The action the user performed.
         public let action: UserAction
+        
+        public init(userID: Int, action: RantInSubscribedFeed.RelatedUserAction.UserAction) {
+            self.userID = userID
+            self.action = action
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: RantInSubscribedFeed.RelatedUserAction.CodingKeys.self)
+            
+            userID = Int(try values.decode(String.self, forKey: .userID))!
+            action = RantInSubscribedFeed.RelatedUserAction.UserAction(rawValue: try values.decode(String.self, forKey: .action))!
+        }
     }
     
     /// The rant's ID.
@@ -166,9 +178,20 @@ public struct RantInSubscribedFeed: Decodable {
         case rant
         case actions
     }
-}
-
-extension RantInSubscribedFeed {
+    
+    public init(id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: Int, isEdited: Bool, relatedUserActions: [RantInSubscribedFeed.RelatedUserAction]) {
+        self.id = id
+        self.text = text
+        self.score = score
+        self.createdTime = createdTime
+        self.attachedImage = attachedImage
+        self.commentCount = commentCount
+        self.tags = tags
+        self.voteState = voteState
+        self.isEdited = isEdited
+        self.relatedUserActions = relatedUserActions
+    }
+    
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -196,14 +219,5 @@ extension RantInSubscribedFeed {
         isEdited = rantInFeedProperties["edited"]! as! Bool
         
         relatedUserActions = try values.decode([RelatedUserAction].self, forKey: .actions)
-    }
-}
-
-extension RantInSubscribedFeed.RelatedUserAction {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: RantInSubscribedFeed.RelatedUserAction.CodingKeys.self)
-        
-        userID = Int(try values.decode(String.self, forKey: .userID))!
-        action = RantInSubscribedFeed.RelatedUserAction.UserAction(rawValue: try values.decode(String.self, forKey: .action))!
     }
 }

--- a/Sources/SwiftRant/UserCredentials.swift
+++ b/Sources/SwiftRant/UserCredentials.swift
@@ -31,6 +31,22 @@ public struct UserCredentials: Codable, Equatable {
             case userID = "user_id"
         }
         
+        public init(tokenID: Int, tokenKey: String, expireTime: Int, userID: Int) {
+            self.tokenID = tokenID
+            self.tokenKey = tokenKey
+            self.expireTime = expireTime
+            self.userID = userID
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            
+            tokenID = try values.decode(Int.self, forKey: .tokenID)
+            tokenKey = try values.decode(String.self, forKey: .tokenKey)
+            expireTime = try values.decode(Int.self, forKey: .expireTime)
+            userID = try values.decode(Int.self, forKey: .userID)
+        }
+        
         public func encode(to encoder: Encoder) throws {
             var values = encoder.container(keyedBy: CodingKeys.self)
             
@@ -48,6 +64,16 @@ public struct UserCredentials: Codable, Equatable {
         case authToken = "auth_token"
     }
     
+    public init(authToken: UserCredentials.AuthToken) {
+        self.authToken = authToken
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        authToken = try values.decode(AuthToken.self, forKey: .authToken)
+    }
+    
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: CodingKeys.self)
         
@@ -59,24 +85,5 @@ public struct UserCredentials: Codable, Equatable {
             lhs.authToken.tokenID == rhs.authToken.tokenID &&
             lhs.authToken.tokenKey == rhs.authToken.tokenKey &&
             lhs.authToken.expireTime == rhs.authToken.expireTime
-    }
-}
-
-extension UserCredentials {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        authToken = try values.decode(AuthToken.self, forKey: .authToken)
-    }
-}
-
-extension UserCredentials.AuthToken {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        tokenID = try values.decode(Int.self, forKey: .tokenID)
-        tokenKey = try values.decode(String.self, forKey: .tokenKey)
-        expireTime = try values.decode(Int.self, forKey: .expireTime)
-        userID = try values.decode(Int.self, forKey: .userID)
     }
 }

--- a/Sources/SwiftRant/UsernameMap.swift
+++ b/Sources/SwiftRant/UsernameMap.swift
@@ -28,6 +28,21 @@ public extension Notifications {
                 case avatar
                 case name
             }
+            
+            public init(avatar: Rant.UserAvatar, name: String, uidForUsername: String) {
+                self.avatar = avatar
+                self.name = name
+                self.uidForUsername = uidForUsername
+            }
+            
+            public init(from decoder: Decoder) throws {
+                let values = try decoder.container(keyedBy: CodingKeys.self)
+                
+                avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
+                name = try values.decode(String.self, forKey: .name)
+                
+                uidForUsername = values.codingPath[values.codingPath.endIndex - 1].stringValue
+            }
         }
         
         /// The array holding the maps.
@@ -46,31 +61,22 @@ public extension Notifications {
                 return nil
             }
         }
-    }
-}
-
-extension Notifications.UsernameMapArray {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
         
-        var tempArray = [UsernameMap]()
-        
-        for key in values.allKeys {
-            let decodedObject = try values.decode(UsernameMap.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
-            tempArray.append(decodedObject)
+        public init(array: [Notifications.UsernameMapArray.UsernameMap]) {
+            self.array = array
         }
         
-        array = tempArray
-    }
-}
-
-extension Notifications.UsernameMapArray.UsernameMap {
-    public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        
-        avatar = try values.decode(Rant.UserAvatar.self, forKey: .avatar)
-        name = try values.decode(String.self, forKey: .name)
-        
-        uidForUsername = values.codingPath[values.codingPath.endIndex - 1].stringValue
+        public init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: DynamicCodingKeys.self)
+            
+            var tempArray = [UsernameMap]()
+            
+            for key in values.allKeys {
+                let decodedObject = try values.decode(UsernameMap.self, forKey: DynamicCodingKeys(stringValue: key.stringValue)!)
+                tempArray.append(decodedObject)
+            }
+            
+            array = tempArray
+        }
     }
 }

--- a/Sources/SwiftRant/Weekly.swift
+++ b/Sources/SwiftRant/Weekly.swift
@@ -32,6 +32,13 @@ public struct WeeklyList: Decodable {
             case rantCount = "num_rants"
         }
         
+        public init(week: Int, prompt: String, date: String, rantCount: Int) {
+            self.week = week
+            self.prompt = prompt
+            self.date = date
+            self.rantCount = rantCount
+        }
+        
         public init(from decoder: Decoder) throws {
             let container: KeyedDecodingContainer<WeeklyList.Week.CodingKeys> = try decoder.container(keyedBy: WeeklyList.Week.CodingKeys.self)
             self.week = try container.decode(Int.self, forKey: WeeklyList.Week.CodingKeys.week)
@@ -48,23 +55,12 @@ public struct WeeklyList: Decodable {
         case weeks
     }
     
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.weeks = try container.decode([WeeklyList.Week].self, forKey: .weeks)
-    }
-}
-
-extension WeeklyList {
     public init(weeks: [WeeklyList.Week]) {
         self.weeks = weeks
     }
-}
-
-extension WeeklyList.Week {
-    public init(week: Int, prompt: String, date: String, rantCount: Int) {
-        self.week = week
-        self.prompt = prompt
-        self.date = date
-        self.rantCount = rantCount
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.weeks = try container.decode([WeeklyList.Week].self, forKey: .weeks)
     }
 }


### PR DESCRIPTION
Added explicit public memberwise initializers for all Model structs. 
This is a suboptimal solution because those initializers need to be maintained when stored properties change in the models, but we have no other choice here, because there is no way to have public synthesized initializers, unfortunately.

I have generated the initializers with Xcode by right clicking on the struct, Refactor and Generate Memberwise Initializers.
Then I have changed internal to public and moved the initializer from the top of the struct to the bottom where the stored property declarations end.

I have also removed the extensions for the initializers which were supposed to make the synthesized initializers work. But because the synthesized inializers are internal, the extensions are not needed anymore. I've moved the initialzers back into the struct bodies.