### PR TITLE
Change `Notifications.Categories`'s enum type to `Int` in order to add support for converting the enum value to both a `String` and an `Int`

### DIFF
--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -20,7 +20,7 @@ public struct Notifications: Decodable {
     
     /// An enumeration representing all different categories of notifications.
     public enum Categories: String, CaseIterable {
-        case all = "all"
+        case all = ""
         case upvotes = "upvotes"
         case mentions = "mentions"
         case comments = "comments"

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -20,11 +20,11 @@ public struct Notifications: Decodable {
     
     /// An enumeration representing all different categories of notifications.
     public enum Categories: String, CaseIterable {
-        case all
-        case upvotes
-        case mentions
-        case comments
-        case subs
+        case all = "all"
+        case upvotes = "upvotes"
+        case mentions = "mentions"
+        case comments = "comments"
+        case subs = "subs"
     }
     
     /// A model representing the amount of all types of unread notifications.

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -19,8 +19,8 @@ struct NotificationFeed: Decodable {
 public struct Notifications: Decodable {
     
     /// An enumeration representing all different categories of notifications.
-    public enum Categories: Int {
-        case all = 0
+    public enum Categories: String, CaseIterable {
+        case all
         case upvotes
         case mentions
         case comments

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -19,8 +19,8 @@ struct NotificationFeed: Decodable {
 public struct Notifications: Decodable {
     
     /// An enumeration representing all different categories of notifications.
-    public enum Categories: String {
-        case all
+    public enum Categories: Int {
+        case all = 0
         case upvotes
         case mentions
         case comments

--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -622,7 +622,7 @@ public class SwiftRant {
             }
         }
         
-        let resourceURL = URL(string: baseURL + "/users/me/notif-feed\(category == .all ? "" : "/\(category.rawValue)")?last_time=\(shouldUseKeychainAndUserDefaults ? (shouldGetNewNotifs ? UserDefaults.standard.integer(forKey: "DRLastNotifCheckTime") : 0) : (shouldGetNewNotifs ? lastCheckTime! : 0))&ext_prof=1&app=3&user_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.userID : token!.authToken.userID)&token_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenID : token!.authToken.tokenID)&token_key=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenKey : token!.authToken.tokenKey)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
+        let resourceURL = URL(string: baseURL + "/users/me/notif-feed\(category == .all ? "" : "/\(String(describing: category))")?last_time=\(shouldUseKeychainAndUserDefaults ? (shouldGetNewNotifs ? UserDefaults.standard.integer(forKey: "DRLastNotifCheckTime") : 0) : (shouldGetNewNotifs ? lastCheckTime! : 0))&ext_prof=1&app=3&user_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.userID : token!.authToken.userID)&token_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenID : token!.authToken.tokenID)&token_key=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenKey : token!.authToken.tokenKey)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
         
         var request = URLRequest(url: resourceURL)
         

--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -622,7 +622,7 @@ public class SwiftRant {
             }
         }
         
-        let resourceURL = URL(string: baseURL + "/users/me/notif-feed\(category == .all ? "" : "/\(String(describing: category))")?last_time=\(shouldUseKeychainAndUserDefaults ? (shouldGetNewNotifs ? UserDefaults.standard.integer(forKey: "DRLastNotifCheckTime") : 0) : (shouldGetNewNotifs ? lastCheckTime! : 0))&ext_prof=1&app=3&user_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.userID : token!.authToken.userID)&token_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenID : token!.authToken.tokenID)&token_key=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenKey : token!.authToken.tokenKey)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
+        let resourceURL = URL(string: baseURL + "/users/me/notif-feed\(category.rawValue)?last_time=\(shouldUseKeychainAndUserDefaults ? (shouldGetNewNotifs ? UserDefaults.standard.integer(forKey: "DRLastNotifCheckTime") : 0) : (shouldGetNewNotifs ? lastCheckTime! : 0))&ext_prof=1&app=3&user_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.userID : token!.authToken.userID)&token_id=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenID : token!.authToken.tokenID)&token_key=\(shouldUseKeychainAndUserDefaults ? tokenFromKeychain!.authToken.tokenKey : token!.authToken.tokenKey)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
         
         var request = URLRequest(url: resourceURL)
         

--- a/Sources/SwiftRant/VoteState.swift
+++ b/Sources/SwiftRant/VoteState.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// An enumeration representing the different types of votes a rant can have.
 public enum VoteState: Int {
     /// Represents the state of a given ++ vote.
     case upvoted = 1

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -240,6 +240,26 @@ final class SwiftRantTests: XCTestCase {
         print("Print your real password: ", terminator: "")
         let password = readLine()
         
+        print("Enter a category of notifications to fetch: ")
+        print("1. all\n2. upvotes\n3. mentions\n4. comments\n5. subs\nSelection: ", terminator: "")
+        var input = readLine() ?? ""
+        
+        var categoryNumber: Int! = Int(input)
+        
+        while categoryNumber == nil || !(0...4).contains(categoryNumber - 1) {
+            print("Invalid category number entered.")
+            
+            print("Enter a category of notifications to fetch: ")
+            print("1. all\n2. upvotes\n3. mentions\n4. comments\n5. subs\nSelection: ", terminator: "")
+            
+            input = readLine() ?? ""
+            categoryNumber = Int(input)
+        }
+        
+        categoryNumber -= 1
+        
+        let category: Notifications.Categories = .init(rawValue: categoryNumber)!
+        
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
@@ -253,7 +273,7 @@ final class SwiftRantTests: XCTestCase {
                 semaphore.signal()
             }*/
             
-            SwiftRant.shared.getNotificationFeed(token: nil, lastCheckTime: nil, shouldGetNewNotifs: false, category: .all) { result in
+            SwiftRant.shared.getNotificationFeed(token: nil, lastCheckTime: nil, shouldGetNewNotifs: false, category: category) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT")

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -258,7 +258,7 @@ final class SwiftRantTests: XCTestCase {
         
         categoryNumber -= 1
         
-        let category: Notifications.Categories = .init(rawValue: categoryNumber)!
+		let category: Notifications.Categories = .allCases[categoryNumber]
         
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
@@ -346,7 +346,7 @@ final class SwiftRantTests: XCTestCase {
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.voteOnRant(nil, rantID: 4811624, vote: 0) { result in
+			SwiftRant.shared.voteOnRant(nil, rantID: 4811624, vote: .unvoted) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")
@@ -383,7 +383,7 @@ final class SwiftRantTests: XCTestCase {
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.voteOnComment(nil, commentID: 4811651, vote: 0) { result in
+			SwiftRant.shared.voteOnComment(nil, commentID: 4811651, vote: .unvoted) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")


### PR DESCRIPTION
# Change `Notifications.Categories`'s enum type to `Int` in order to add support for converting the enum value to both a `String` and an `Int`

## Purpose

With this change, developers will be able to turn the value of a `Notifications.Categories` to both an `Int` as well as a `String`. Currently, it is only possible to convert `Notifications.Categories` to a `String`.

Usage example with the change:

```swift
import SwiftRant

let category: Notifications.Categories = .upvotes

print(category.rawValue) // 1
print(String(describing: category)) // "upvotes"
```

This boosts the enum's utility.