### PR TITLE
using VoteState enum everywhere

### DIFF
--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -26,12 +26,17 @@ public struct Comment: Decodable, Identifiable {
     /// The Unix timestamp at which the comment was posted.
     public let createdTime: Int
     
+    public var voteStateRaw: Int
+    
     /// The current logged-in user's vote on the comment.
-    /// * 1 = upvote
-    /// * 0 = unvoted
-    /// * -1 = downvote
-    /// * -2 = voting disabled (the comment belongs to the user whose token was used to fetch the comment)
-    public var voteState: Int
+    public var voteState: VoteState {
+        get {
+            return VoteState(rawValue: voteStateRaw) ?? .unvotable
+        }
+        set {
+            voteStateRaw = newValue.rawValue
+        }
+    }
     
     /// If the comment includes URLs in the text, those that were successfully parsed by the server will be in this array.
     public var links: [Rant.Link]?
@@ -60,7 +65,7 @@ public struct Comment: Decodable, Identifiable {
              body,
              score,
              createdTime = "created_time",
-             voteState = "vote_state",
+             voteStateRaw = "vote_state",
              links,
              userID = "user_id",
              username = "user_username",
@@ -70,14 +75,14 @@ public struct Comment: Decodable, Identifiable {
              attachedImage = "attached_image"
     }
     
-    public init(uuid: UUID = UUID(), id: Int, rantID: Int, body: String, score: Int, createdTime: Int, voteState: Int, links: [Rant.Link]?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, isUserDPP: Int?, attachedImage: Rant.AttachedImage?) {
+    public init(uuid: UUID = UUID(), id: Int, rantID: Int, body: String, score: Int, createdTime: Int, voteState: VoteState, links: [Rant.Link]?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, isUserDPP: Int?, attachedImage: Rant.AttachedImage?) {
         self.uuid = uuid
         self.id = id
         self.rantID = rantID
         self.body = body
         self.score = score
         self.createdTime = createdTime
-        self.voteState = voteState
+        self.voteStateRaw = voteState.rawValue
         self.links = links
         self.userID = userID
         self.username = username
@@ -94,7 +99,7 @@ public struct Comment: Decodable, Identifiable {
         body = try values.decode(String.self, forKey: .body)
         score = try values.decode(Int.self, forKey: .score)
         createdTime = try values.decode(Int.self, forKey: .createdTime)
-        voteState = try values.decode(Int.self, forKey: .voteState)
+        voteStateRaw = try values.decode(Int.self, forKey: .voteStateRaw)
         links = try? values.decodeIfPresent([Rant.Link].self, forKey: .links)
         userID = try values.decode(Int.self, forKey: .userID)
         username = try values.decode(String.self, forKey: .username)

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -177,15 +177,17 @@ public struct Rant: Decodable, Identifiable {
     /// The tags the rant is listed under.
     public let tags: [String]
     
-    /**
-     The current logged-in user's vote on the rant.
-     
-     * `1` = upvote
-     * `0` = unvoted
-     * `-1` = downvote
-     * `-2` = voting disabled (the rant belongs to the user whose token was used to fetch the rant)
-     */
-    public var voteState: Int
+    public var voteStateRaw: Int
+    
+    /// The current logged-in user's vote on the rant.
+    public var voteState: VoteState {
+        get {
+            return VoteState(rawValue: voteStateRaw) ?? .unvotable
+        }
+        set {
+            voteStateRaw = newValue.rawValue
+        }
+    }
     
     /// Whether or not the rant's author has edited the rant in the past.
     public let isEdited: Bool
@@ -283,7 +285,7 @@ public struct Rant: Decodable, Identifiable {
         case undefined = 7
     }
     
-    public init(weekly: Rant.Weekly?, id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: Int, isEdited: Bool, isFavorite: Int? = nil, link: String?, links: [Rant.Link]? = nil, collabTypeLong: String?, collabDescription: String?, collabTechStack: String?, collabTeamSize: String?, collabURL: String?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, userAvatarLarge: Rant.UserAvatar, isUserDPP: Int?) {
+    public init(weekly: Rant.Weekly?, id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: VoteState, isEdited: Bool, isFavorite: Int? = nil, link: String?, links: [Rant.Link]? = nil, collabTypeLong: String?, collabDescription: String?, collabTechStack: String?, collabTeamSize: String?, collabURL: String?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, userAvatarLarge: Rant.UserAvatar, isUserDPP: Int?) {
         self.weekly = weekly
         self.id = id
         self.text = text
@@ -292,7 +294,7 @@ public struct Rant: Decodable, Identifiable {
         self.attachedImage = attachedImage
         self.commentCount = commentCount
         self.tags = tags
-        self.voteState = voteState
+        self.voteStateRaw = voteState.rawValue
         self.isEdited = isEdited
         self.isFavorite = isFavorite
         self.link = link
@@ -326,7 +328,7 @@ public struct Rant: Decodable, Identifiable {
         
         commentCount = try values.decode(Int.self, forKey: .commentCount)
         tags = try values.decode([String].self, forKey: .tags)
-        voteState = try values.decode(Int.self, forKey: .voteState)
+        voteStateRaw = try values.decode(Int.self, forKey: .voteState)
         weekly = try? values.decode(Weekly.self, forKey: .weekly)
         isEdited = try values.decode(Bool.self, forKey: .isEdited)
         isFavorite = try? values.decode(Int.self, forKey: .isFavorite)

--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -32,20 +32,9 @@ public struct RantInFeed: Decodable, Identifiable {
     /// The tags this rant is listed under.
     public let tags: [String]
     
-    /// The current logged-in user's vote on the rant.
-    /// * `1` = Upvote
-    /// * `0` = Unvoted
-    /// * `-1` = Downvote
-    /// * `-2` = Voting disabled (the rant belongs to the user whose token was used to fetch the rant)
     public var voteStateRaw: Int
     
-    public enum VoteState: Int {
-        case upvoted = 1
-        case unvoted = 0
-        case downvoted = -1
-        case unvotable = -2
-    }
-    
+    /// The current logged-in user's vote on the rant.
     public var voteState: VoteState {
         get {
             return VoteState(rawValue: voteStateRaw) ?? .unvotable

--- a/Sources/SwiftRant/RantInSubscribedFeed.swift
+++ b/Sources/SwiftRant/RantInSubscribedFeed.swift
@@ -161,12 +161,17 @@ public struct RantInSubscribedFeed: Decodable {
     /// The tags this rant is listed under.
     public let tags: [String]
     
+    public var voteStateRaw: Int
+    
     /// The current logged-in user's vote on the rant.
-    /// * `1` = Upvote
-    /// * `0` = Unvoted
-    /// * `-1` = Downvote
-    /// * `-2` = Voting disabled (the rant belongs to the user whose token was used to fetch the rant)
-    public var voteState: Int
+    public var voteState: VoteState {
+        get {
+            return VoteState(rawValue: voteStateRaw) ?? .unvotable
+        }
+        set {
+            voteStateRaw = newValue.rawValue
+        }
+    }
     
     /// Whether or not the rant was edited in the past.
     public let isEdited: Bool
@@ -179,7 +184,7 @@ public struct RantInSubscribedFeed: Decodable {
         case actions
     }
     
-    public init(id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: Int, isEdited: Bool, relatedUserActions: [RantInSubscribedFeed.RelatedUserAction]) {
+    public init(id: Int, text: String, score: Int, createdTime: Int, attachedImage: Rant.AttachedImage?, commentCount: Int, tags: [String], voteState: VoteState, isEdited: Bool, relatedUserActions: [RantInSubscribedFeed.RelatedUserAction]) {
         self.id = id
         self.text = text
         self.score = score
@@ -187,7 +192,7 @@ public struct RantInSubscribedFeed: Decodable {
         self.attachedImage = attachedImage
         self.commentCount = commentCount
         self.tags = tags
-        self.voteState = voteState
+        self.voteStateRaw = voteState.rawValue
         self.isEdited = isEdited
         self.relatedUserActions = relatedUserActions
     }
@@ -214,7 +219,7 @@ public struct RantInSubscribedFeed: Decodable {
         
         tags = rantInFeedProperties["tags"]! as! [String]
         
-        voteState = rantInFeedProperties["vote_state"]! as! Int
+        voteStateRaw = rantInFeedProperties["vote_state"]! as! Int
         
         isEdited = rantInFeedProperties["edited"]! as! Bool
         

--- a/Sources/SwiftRant/VoteState.swift
+++ b/Sources/SwiftRant/VoteState.swift
@@ -1,0 +1,23 @@
+//
+//  VoteState.swift
+//  
+//
+//  Created by Wilhelm Oks on 21.09.22.
+//
+
+import Foundation
+
+public enum VoteState: Int {
+    /// Represents the state of a given ++ vote.
+    case upvoted = 1
+    
+    /// Represents the state of no votes given.
+    case unvoted = 0
+    
+    /// Represents the state of a given -- vote.
+    case downvoted = -1
+    
+    /// Represents the state of not being able to vote.
+    /// It can be unvotable if the rant or comment belongs to the logged in user.
+    case unvotable = -2
+}


### PR DESCRIPTION
These changes were made so that the user of SwiftRant can use the VoteState enum instead of the Int everywhere (just like it was done in RantInFeed).

I've pulled the VoteState enum out of RantInFeed, so that it can be used more generally.
All models that had the `voteState: Int` property, are changed so that they have a `voteState: VoteState` computed propery and a `voteStateRaw: Int` stored property.
The initializers of the models were adjusted for that change.

This is a breaking change.
