### PR TITLE
SwiftRant public init

### DIFF
--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -59,8 +59,8 @@ public class SwiftRant {
     /// Initializes the SwiftRant library.
     ///
     /// - Parameter shouldUseKeychainAndUserDefaults: Whether or not the library should store devRant access tokens and the user's personal username and password in the Keychain and small caches in User Defaults. If no value is given, Keychain and User Defaults for the instance are automatically enabled.
-    /// - Returns: a new SwiftRant class.
-    init(shouldUseKeychainAndUserDefaults: Bool = true) {
+    /// - Returns: a new SwiftRant class instance.
+    public init(shouldUseKeychainAndUserDefaults: Bool = true) {
         self.shouldUseKeychainAndUserDefaults = shouldUseKeychainAndUserDefaults
     }
     

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -326,7 +326,7 @@ final class SwiftRantTests: XCTestCase {
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.voteOnRant(nil, rantID: 4811624, vote: 0) { result in
+            SwiftRant.shared.voteOnRant(nil, rantID: 4811624, vote: .unvoted) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")
@@ -363,7 +363,7 @@ final class SwiftRantTests: XCTestCase {
         SwiftRant.shared.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.voteOnComment(nil, commentID: 4811651, vote: 0) { result in
+            SwiftRant.shared.voteOnComment(nil, commentID: 4811651, vote: .unvoted) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")


### PR DESCRIPTION
Made the initializer of the SwiftRant class public so that SwiftRant can be used without the shared instance and without automatic Keychain and UserDefaults.

Also fixed build errors in the Tests code.