### PR TITLE
Adding missing ampersand (&) before the url parameter prev_set

### DIFF
--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -315,7 +315,7 @@ public class SwiftRant {
                 resourceURL = URL(string: baseURL + "/devrant/rants?limit=20&skip=\(String(skip))&sort=algo&app=3&plat=1&nari=1&user_id=\(String(currentToken.authToken.userID))&token_id=\(String(currentToken.authToken.tokenID))&token_key=\(currentToken.authToken.tokenKey)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)!
             }
         } else {
-            resourceURL = URL(string: baseURL + "/devrant/rants?limit=20&skip=\(String(skip))&sort=algo\(prevSet != nil ? "prev_set=\(prevSet!)" : "")&app=3&plat=1&nari=1&user_id=\(String(token!.authToken.userID))&token_id=\(String(token!.authToken.tokenID))&token_key=\(token!.authToken.tokenKey)")!
+            resourceURL = URL(string: baseURL + "/devrant/rants?limit=20&skip=\(String(skip))&sort=algo\(prevSet != nil ? "&prev_set=\(prevSet!)" : "")&app=3&plat=1&nari=1&user_id=\(String(token!.authToken.userID))&token_id=\(String(token!.authToken.tokenID))&token_key=\(token!.authToken.tokenKey)")!
         }
         
         


### PR DESCRIPTION
Adding missing ampersand (&) before the url parameter prev_set.
I suspect this is the reason why the feed doesn't work when using SwiftRant without keychain & userdefaults.