### PR TITLE
Added Sort and Range for the rant feed

### DIFF
--- a/Sources/SwiftRant/RantFeed.swift
+++ b/Sources/SwiftRant/RantFeed.swift
@@ -172,3 +172,32 @@ public struct RantFeed: Decodable {
         news = try values.decodeIfPresent(News.self, forKey: .news)
     }
 }
+
+//MARK: - sort & range
+
+public extension RantFeed {
+    enum Sort {
+        /// The devRant algorithm decides what rants appear in the feed.
+        case algorithm
+        
+        /// The most recent rants appear in the feed.
+        case recent
+        
+        /// The top rated rants appear in the feed.
+        case top(range: Range)
+    }
+    
+    enum Range {
+        /// Rants from the one day.
+        case day
+        
+        /// Rants from the one week.
+        case week
+        
+        /// Rants from the one month.
+        case month
+        
+        /// Rants from all time.
+        case all
+    }
+}


### PR DESCRIPTION
Added Sort and Range for the rant feed so that it can be configured like in the official devRant app.

I am a bit worried about the last set that is stored in UserDefaults (DRLastSet).
That will probably not work well together with switching Sort for the feed.
And I don't have a good idea how to handle it.
Maybe remove the automatic storage by SwiftRant and leave it to handle for the user of SwiftRant? Because only the user knows when it is appropriate to clear the last set, e.g. when switching to another Sort mode, etc.

This should work fine with shouldUseKeychainAndUserDefaults==false, though.