### PR TITLE
Hashable identifiable models

### DIFF
--- a/Sources/SwiftRant/AvatarCustomization.swift
+++ b/Sources/SwiftRant/AvatarCustomization.swift
@@ -14,10 +14,24 @@ import AppKit
 #endif
 
 /// A model representing the results of the customization query from the devRant servers.
-public struct AvatarCustomizationResults: Decodable {
+public struct AvatarCustomizationResults: Decodable, Hashable {
     
     /// A class representing a customization image in the avatar editor.
-    public class AvatarCustomizationImage: Decodable {
+    public class AvatarCustomizationImage: Decodable, Hashable, Equatable {
+        //TODO: check if this class can be a struct. If yes, change it to struct and remove the explicit functions to conform to Hashable and Equatable, because they are synthesized automatically for structs.
+        
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(backgroundColor)
+            hasher.combine(fullImageName)
+            hasher.combine(midImageName)
+        }
+        
+        public static func == (lhs: AvatarCustomizationResults.AvatarCustomizationImage, rhs: AvatarCustomizationResults.AvatarCustomizationImage) -> Bool {
+            return
+                rhs.backgroundColor == lhs.backgroundColor &&
+                rhs.fullImageName == lhs.fullImageName &&
+                rhs.midImageName == lhs.midImageName
+        }
         
         /// The background color in hexadecimal.
         public let backgroundColor: String
@@ -159,14 +173,14 @@ public struct AvatarCustomizationResults: Decodable {
     }
     
     /// A model representing the current info about the user.
-    public struct AvatarCustomizationCurrentUserInfo: Decodable {
+    public struct AvatarCustomizationCurrentUserInfo: Decodable, Hashable {
         
         /// The user's current score on devRant.
         public var score: Int
     }
     
     /// A model representing an avatar customization type.
-    public struct AvatarCustomizationType: Decodable {
+    public struct AvatarCustomizationType: Decodable, Hashable {
         
         /// The gender for which the customization type is made for, if the type is gender-specific.
         public let forGender: String?
@@ -189,7 +203,7 @@ public struct AvatarCustomizationResults: Decodable {
     }
     
     /// A model representing an avatar customization option.
-    public struct AvatarCustomizationOption: Decodable {
+    public struct AvatarCustomizationOption: Decodable, Hashable {
         
         /// The background color of the option's image in hexadecimal.
         public let backgroundColor: String?

--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// Holds information about a single comment.
 public struct Comment: Decodable, Identifiable, Hashable {
+    public let uuid = UUID()
+    
     /// The comment's ID.
     public let id: Int
     

--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Holds information about a single comment.
-public struct Comment: Decodable, Identifiable {
+public struct Comment: Decodable, Identifiable, Hashable {
     var uuid = UUID()
     
     /// The comment's ID.

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -96,6 +96,7 @@ public struct Notifications: Decodable, Hashable {
 
 /// A model representing a single notification.
 public struct Notification: Decodable, Equatable, Hashable {
+    public let uuid = UUID()
     
     /// The comment's ID, if the notification is linked to a comment.
     public let commentID: Int?

--- a/Sources/SwiftRant/NotificationFeed.swift
+++ b/Sources/SwiftRant/NotificationFeed.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct NotificationFeed: Decodable {
+struct NotificationFeed: Decodable, Hashable {
     public let data: Notifications
     
     public init(data: Notifications) {
@@ -16,7 +16,7 @@ struct NotificationFeed: Decodable {
 }
 
 /// A model representing the notification data.
-public struct Notifications: Decodable {
+public struct Notifications: Decodable, Hashable {
     
     /// An enumeration representing all different categories of notifications.
     public enum Categories: String, CaseIterable {
@@ -28,7 +28,7 @@ public struct Notifications: Decodable {
     }
     
     /// A model representing the amount of all types of unread notifications.
-    public struct UnreadNotifications: Decodable {
+    public struct UnreadNotifications: Decodable, Hashable {
         
         /// The total amount of unread notifications in the "all" category
         public let all: Int
@@ -95,7 +95,7 @@ public struct Notifications: Decodable {
 }
 
 /// A model representing a single notification.
-public struct Notification: Decodable, Equatable {
+public struct Notification: Decodable, Equatable, Hashable {
     
     /// The comment's ID, if the notification is linked to a comment.
     public let commentID: Int?

--- a/Sources/SwiftRant/Profile.swift
+++ b/Sources/SwiftRant/Profile.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 /// Holds information about a single user's profile.
-public struct Profile: Decodable {
+public struct Profile: Decodable, Hashable {
     
     /// A structure that coalesces both the content itself and the amount of different types of content created by the user.
-    public struct OuterUserContent: Decodable {
+    public struct OuterUserContent: Decodable, Hashable {
         /// The user's content.
         public let content: InnerUserContent
         
@@ -25,7 +25,7 @@ public struct Profile: Decodable {
     }
     
     /// The actual content created by the user.
-    public struct InnerUserContent: Decodable {
+    public struct InnerUserContent: Decodable, Hashable {
         
         /// The rants the user created.
         public var rants: [RantInFeed]
@@ -79,7 +79,7 @@ public struct Profile: Decodable {
     }
     
     /// A structure representing the amount of content the user has created for every single type of content.
-    public struct UserCounts: Decodable {
+    public struct UserCounts: Decodable, Hashable {
         
         /// The amount of rants the user has posted.
         public let rants: Int

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 /// Holds information about a single rant.
-public struct Rant: Decodable, Identifiable {
+public struct Rant: Decodable, Identifiable, Hashable {
     
     /// Holds information about a specific weekly group rant.
-    public struct Weekly: Decodable {
+    public struct Weekly: Decodable, Hashable {
         
         /// The date the weekly group rant was published.
         public let date: String
@@ -34,7 +34,7 @@ public struct Rant: Decodable, Identifiable {
     }
 
     /// Holds information about links inside rants and comments.
-    public struct Link: Decodable {
+    public struct Link: Decodable, Hashable {
         
         /// The type of link.
         /// The types that exist are `url` and `mention`.
@@ -105,7 +105,7 @@ public struct Rant: Decodable, Identifiable {
     }
 
     /// Holds information about attached images in rants and comments.
-    public struct AttachedImage: Decodable {
+    public struct AttachedImage: Decodable, Hashable {
         //let attached_image: String?
         
         /// The attached image's URL.
@@ -125,7 +125,7 @@ public struct Rant: Decodable, Identifiable {
     }
 
     /// Holds information about a user's avatar.
-    public struct UserAvatar: Decodable, Equatable {
+    public struct UserAvatar: Decodable, Equatable, Hashable {
         
         /// The user's background color, in hex.
         public let backgroundColor: String

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -152,6 +152,8 @@ public struct Rant: Decodable, Identifiable, Hashable {
         }
     }
     
+    public let uuid = UUID()
+    
     /// If the rant is taking part in the weekly group rant, this variable will be populated with information regarding it.
     public let weekly: Weekly?
     

--- a/Sources/SwiftRant/RantFeed.swift
+++ b/Sources/SwiftRant/RantFeed.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 /// Contains the contents of a devRant rant feed.
-public struct RantFeed: Decodable {
+public struct RantFeed: Decodable, Hashable {
     
     /// Contains settings about notifications.
-    public struct Settings: Codable {
+    public struct Settings: Codable, Hashable {
         
         /// Whether notifications are available.
         public let notificationState: String
@@ -38,7 +38,7 @@ public struct RantFeed: Decodable {
     }
     
     /// Contains the amount of unread notifications.
-    public struct Unread: Decodable {
+    public struct Unread: Decodable, Hashable {
         
         /// The total count of unread notifications.
         public let total: Int
@@ -50,7 +50,7 @@ public struct RantFeed: Decodable {
     
     /// Contains information about news given in rant feeds.
     /// - note: This is mostly used for Weekly Group Rants.
-    public struct News: Decodable {
+    public struct News: Decodable, Hashable, Identifiable {
         
         /// The ID of the news.
         public let id: Int

--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Holds shortened and summarized information about a specific rant. Used when the rant is contained in a feed.
-public struct RantInFeed: Decodable, Identifiable {
+public struct RantInFeed: Decodable, Identifiable, Hashable {
     let uuid = UUID()
     
     /// The rant's ID.

--- a/Sources/SwiftRant/RantInFeed.swift
+++ b/Sources/SwiftRant/RantInFeed.swift
@@ -9,6 +9,8 @@ import Foundation
 
 /// Holds shortened and summarized information about a specific rant. Used when the rant is contained in a feed.
 public struct RantInFeed: Decodable, Identifiable, Hashable {
+    public let uuid = UUID()
+    
     /// The rant's ID.
     public let id: Int
     

--- a/Sources/SwiftRant/RantInSubscribedFeed.swift
+++ b/Sources/SwiftRant/RantInSubscribedFeed.swift
@@ -98,10 +98,10 @@ extension UnkeyedDecodingContainer {
 }
 
 /// A structure representing a single rant/post inside a Subscribed feed.
-public struct RantInSubscribedFeed: Decodable {
+public struct RantInSubscribedFeed: Decodable, Hashable {
     
     /// A structure representing one action a specific user has performed on a post listed in a Subscribed feed.
-    public struct RelatedUserAction: Decodable {
+    public struct RelatedUserAction: Decodable, Hashable {
         
         /// An enumeration listing the different types of actions the user could've performed on the post.
         public enum UserAction: String {

--- a/Sources/SwiftRant/SubscribedFeed.swift
+++ b/Sources/SwiftRant/SubscribedFeed.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-public struct SubscribedFeed: Decodable {
+public struct SubscribedFeed: Decodable, Hashable {
     
     /// A structure representing information about the current page of the Subscribed feed.
-    public struct PageInfo: Decodable {
+    public struct PageInfo: Decodable, Hashable {
         /// A signature marking the end of the current page. Use this to get a fresh list of rants that weren't showcased in this feed.
         public let endCursor: String
         
@@ -36,7 +36,7 @@ public struct SubscribedFeed: Decodable {
     }
     
     /// A structure representing the list of users the devRant API thinks it can recommend to the user.
-    public struct RecommendedUsers: Decodable {
+    public struct RecommendedUsers: Decodable, Hashable {
         
         /// The list of the IDs of the recommended users.
         public var users: [Int]
@@ -74,7 +74,7 @@ public struct SubscribedFeed: Decodable {
     
     /// A structure representing a wrapper for an array holding a map of the users showcased and recommended in this feed.
     /// - Warning: **This struct is incompatible with** ``Notifications/UsernameMapArray``**, because of different key names between the two responses.** This is not a limitation of this library, but a screw-up on devRant's side.
-    public struct UsernameMap: Decodable {
+    public struct UsernameMap: Decodable, Hashable {
         
         /// A structure representing a single user in the username map.
         public struct User: Decodable, Hashable {
@@ -82,9 +82,12 @@ public struct SubscribedFeed: Decodable {
                 return lhs.username == rhs.username && lhs.avatar == rhs.avatar && lhs.score == rhs.score && lhs.userID == rhs.userID
             }
             
+            /* The hash function should take into account all stored properties, not just the id.
+             * Because it should be used to recognize changes in the object, not to identify the object.
             public func hash(into hasher: inout Hasher) {
                 hasher.combine(userID)
             }
+             */
             
             /// The user's username.
             public let username: String

--- a/Sources/SwiftRant/UserCredentials.swift
+++ b/Sources/SwiftRant/UserCredentials.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 /// A structure representing a user's credentials for accessing the devRant servers.
-public struct UserCredentials: Codable, Equatable {
+public struct UserCredentials: Codable, Equatable, Hashable {
     
     /// A structure representing a user's auth token.
-    public struct AuthToken: Codable {
+    public struct AuthToken: Codable, Hashable {
         /// The user's token ID.
         public let tokenID: Int
         

--- a/Sources/SwiftRant/UsernameMap.swift
+++ b/Sources/SwiftRant/UsernameMap.swift
@@ -10,10 +10,10 @@ import Foundation
 public extension Notifications {
     
     /// A wrapper for an array holding a map of the usernames and their corresponding notifications.
-    struct UsernameMapArray: Decodable {
+    struct UsernameMapArray: Decodable, Hashable {
         
         /// A model representing a map of a username and its corresponding notification.
-        public struct UsernameMap: Decodable {
+        public struct UsernameMap: Decodable, Hashable {
             
             /// The user's avatar.
             public let avatar: Rant.UserAvatar

--- a/Sources/SwiftRant/Weekly.swift
+++ b/Sources/SwiftRant/Weekly.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 /// A struct representing a list of Weekly Rant weeks.
-public struct WeeklyList: Decodable {
+public struct WeeklyList: Decodable, Hashable {
     
     /// A struct representing the initial information for a since rant week.
-    public struct Week: Decodable {
+    public struct Week: Decodable, Hashable {
         
         /// The week number.
         public let week: Int


### PR DESCRIPTION
The usage of Hashable, Equatable and Identifyable wasn't consistent and even semantically wrong in some places.
The changes in this PR are an attempt to fix this and to provide comparability and identity features in a standard way. 
Code that was relying on the previous (wrong) semantics should be checked and changed after merging this PR.

Following changes have been made:
* All models have conformance to Hashable. This allows to recognize changes and check for equality (not identity).
* Some models got conformance to Identifiable, if they have stored properties that can identify them.
* Removed SubscribedFeed.UsernameMap.User explicit hash function. See the reasoning in the comment in code.

First I wanted to remove all uuid properties because they shouldn't be needed in theory. But on the other hand, they can be handy to trigger updates in the UI everytime that a new model is fetched. Like a marker property for newly created model objects.
I'm still not happy with that because it feels like this is not the correct way to do it and there should be a better solution. I will revisit and rethink it later.
