### PR TITLE
decoding notif_state as Int instead of String if it fails

### DIFF
--- a/Sources/SwiftRant/RantFeed.swift
+++ b/Sources/SwiftRant/RantFeed.swift
@@ -32,7 +32,12 @@ public struct RantFeed: Decodable {
         public init(from decoder: Decoder) throws {
             let values = try decoder.container(keyedBy: CodingKeys.self)
             
-            notificationState = try values.decode(String.self, forKey: .notificationState)
+            do {
+                notificationState = try values.decode(String.self, forKey: .notificationState)
+            } catch {
+                // The notif_state can be the integer -1 instead of a string. Probably when the account's email has not been verified yet.
+                notificationState = String(try values.decode(Int.self, forKey: .notificationState))
+            }
             notificationToken = try? values.decode(String.self, forKey: .notificationToken)
         }
     }


### PR DESCRIPTION
I have created a new devRant account and the feed could not be decoded, because notif_state was -1 and it tried to decode it as a String. This happens probably when the account has not verified its email yet.
So to fix it, I added code to decode it as an Int and then converting it into a String, if it fails.