### PR TITLE
Add `isEdited` Property to `Comment`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftKeychainWrapper",
+        "repositoryURL": "https://github.com/jrendel/SwiftKeychainWrapper",
+        "state": {
+          "branch": null,
+          "revision": "185a3165346a03767101c4f62e9a545a0fe0530f",
+          "version": "4.0.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -38,6 +38,15 @@ public struct Comment: Decodable, Identifiable, Hashable {
         }
     }
     
+    public var isEditedRaw: Bool?
+    
+    /// Whether or not the comment's author has edited the comment in the past.
+    public var isEdited: Bool {
+        get {
+            return isEditedRaw ?? false
+        }
+    }
+    
     /// If the comment includes URLs in the text, those that were successfully parsed by the server will be in this array.
     public var links: [Rant.Link]?
     
@@ -73,15 +82,17 @@ public struct Comment: Decodable, Identifiable, Hashable {
              userAvatar = "user_avatar",
              isUserDPP = "user_dpp",
              attachedImage = "attached_image"
+        case isEditedRaw = "edited"
     }
     
-    public init(id: Int, rantID: Int, body: String, score: Int, createdTime: Int, voteState: VoteState, links: [Rant.Link]?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, isUserDPP: Int?, attachedImage: Rant.AttachedImage?) {
+    public init(id: Int, rantID: Int, body: String, score: Int, createdTime: Int, voteState: VoteState, isEdited: Bool = false, links: [Rant.Link]?, userID: Int, username: String, userScore: Int, userAvatar: Rant.UserAvatar, isUserDPP: Int?, attachedImage: Rant.AttachedImage?) {
         self.id = id
         self.rantID = rantID
         self.body = body
         self.score = score
         self.createdTime = createdTime
         self.voteStateRaw = voteState.rawValue
+        self.isEditedRaw = isEdited
         self.links = links
         self.userID = userID
         self.username = username
@@ -99,7 +110,14 @@ public struct Comment: Decodable, Identifiable, Hashable {
         score = try values.decode(Int.self, forKey: .score)
         createdTime = try values.decode(Int.self, forKey: .createdTime)
         voteStateRaw = try values.decode(Int.self, forKey: .voteStateRaw)
-        links = try? values.decodeIfPresent([Rant.Link].self, forKey: .links)
+        
+        if values.contains(.isEditedRaw) {
+            isEditedRaw = try values.decodeIfPresent(Bool.self, forKey: .isEditedRaw)
+        } else {
+            isEditedRaw = false
+        }
+        
+        links = try values.decodeIfPresent([Rant.Link].self, forKey: .links)
         userID = try values.decode(Int.self, forKey: .userID)
         username = try values.decode(String.self, forKey: .username)
         userScore = try values.decode(Int.self, forKey: .userScore)

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -193,6 +193,7 @@ final class SwiftRantTests: XCTestCase {
     }
     
     func testRantFromID() throws {
+        let dRAPI = SwiftRant(shouldUseKeychainAndUserDefaults: false)
         let keychainWrapper = KeychainWrapper(serviceName: "SwiftRant", accessGroup: "SwiftRantAccessGroup")
         
         let semaphore = DispatchSemaphore(value: 0)
@@ -203,10 +204,10 @@ final class SwiftRantTests: XCTestCase {
         print("Print your real password: ", terminator: "")
         let password = readLine()
         
-        SwiftRant.shared.logIn(username: username!, password: password!) { result in
+        dRAPI.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.getRantFromID(token: nil, id: 5055500, lastCommentID: nil) { result in
+            dRAPI.getRantFromID(token: try! result.get(), id: 4831495, lastCommentID: nil) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT")


### PR DESCRIPTION
This adds the `isEdited` property to the `Comment` struct.

Since this property shows up only on edited comments, I had to make an optional `isEditedRaw` property `nil` and a computed `isEdited` wrapper property in order to remove ambiguity and provide a default value that devs can rely on.

If I made `isEdited` the actual property that was decoded and had to have a default value and the property's type would not be `Optional<Bool>`, the decoder would always fail on comments that are not edited, because the property is non-optional and the `edited` key in the JSON would not be present, immediately failing and resulting in an empty comment array/API method failure.

If you have any way to improve on this (somewhat) subpar implementation, please do. At least it works!