### PR TITLE
Add missing User Defaults store call in `getNotificationFeed`

### DIFF
--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -662,6 +662,8 @@ public class SwiftRant {
         
         session.dataTask(with: request) { data, response, error in
             if let data = data {
+                let date = Date()
+                
                 let decoder = JSONDecoder()
                 
                 let notificationResult = try? decoder.decode(NotificationFeed.self, from: data)
@@ -684,6 +686,8 @@ public class SwiftRant {
                     completionHandler(.failure(SwiftRantError(message: "An unknown error has occurred.")))
                     return
                 } else {
+                    UserDefaults.standard.set(date.timeIntervalSince1970, forKey: "DRLastNotifCheckTime")
+                    
                     completionHandler(.success(notificationResult!.data))
                     return
                 }


### PR DESCRIPTION
The function tries to access User Defaults in order to check the stored timestamp of the last request for notifications. The problem is that the call to **store** the timestamp in case of success is never performed, therefore it always gets 0 in the last timestamp and always returns all notifications. This pull request fixes it.