### PR TITLE
Fix for the `Link.calculatedRange` issue

### DIFF
--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -128,19 +128,21 @@ public struct Comment: Decodable, Identifiable, Hashable {
         if links != nil {
             let stringAsData = body.data(using: .utf8)!
             
-            var temporaryStringBytes = Data()
-            var temporaryGenericUseString = ""
+            //var temporaryStringBytes = Data()
+            //var temporaryGenericUseString = ""
             
             for i in 0..<(links!.count) {
                 debugPrint("DECODING LINK!")
                 if links![i].start == nil && links![i].end == nil {
                     links![i].calculatedRange = (body as NSString).range(of: links![i].title)
                 } else {
-                    temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
+                    /*temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
                     
                     temporaryGenericUseString = String(data: temporaryStringBytes, encoding: .utf8)!
                     
-                    links![i].calculatedRange = (body as NSString).range(of: temporaryGenericUseString)
+                    links![i].calculatedRange = (body as NSString).range(of: temporaryGenericUseString)*/
+                    
+                    links![i].calculatedRange = body.charRangeForByteRange(range: NSRange(location: links![i].start!, length: links![i].end! - links![i].start!))
                 }
             }
         }

--- a/Sources/SwiftRant/Comment.swift
+++ b/Sources/SwiftRant/Comment.swift
@@ -143,6 +143,7 @@ public struct Comment: Decodable, Identifiable, Hashable {
                     links![i].calculatedRange = (body as NSString).range(of: temporaryGenericUseString)*/
                     
                     links![i].calculatedRange = body.charRangeForByteRange(range: NSRange(location: links![i].start!, length: links![i].end! - links![i].start!))
+                    debugPrint(links![i].calculatedRange!)
                 }
             }
         }
@@ -150,21 +151,23 @@ public struct Comment: Decodable, Identifiable, Hashable {
     
     public mutating func precalculateLinkRanges() {
         if links != nil {
-            let stringAsData = body.data(using: .utf8)!
+            //let stringAsData = body.data(using: .utf8)!
             
-            var temporaryStringBytes = Data()
-            var temporaryGenericUseString = ""
+            //var temporaryStringBytes = Data()
+            //var temporaryGenericUseString = ""
             
             for i in 0..<(links!.count) {
                 debugPrint("DECODING LINK!")
                 if links![i].start == nil && links![i].end == nil {
                     links![i].calculatedRange = (body as NSString).range(of: links![i].title)
                 } else {
-                    temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
+                    /*temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
                     
                     temporaryGenericUseString = String(data: temporaryStringBytes, encoding: .utf8)!
                     
-                    links![i].calculatedRange = (body as NSString).range(of: temporaryGenericUseString)
+                    links![i].calculatedRange = (body as NSString).range(of: temporaryGenericUseString)*/
+                    
+                    links![i].calculatedRange = body.charRangeForByteRange(range: NSRange(location: links![i].start!, length: links![i].end! - links![i].start!))
                 }
             }
         }

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -101,6 +101,8 @@ public struct Rant: Decodable, Identifiable, Hashable {
             title = try values.decode(String.self, forKey: .title)
             start = try values.decodeIfPresent(Int.self, forKey: .start)
             end = try values.decodeIfPresent(Int.self, forKey: .end)
+            
+            
         }
     }
 

--- a/Sources/SwiftRant/Rant.swift
+++ b/Sources/SwiftRant/Rant.swift
@@ -311,6 +311,25 @@ public struct Rant: Decodable, Identifiable, Hashable {
         self.userAvatar = userAvatar
         self.userAvatarLarge = userAvatarLarge
         self.isUserDPP = isUserDPP
+        
+        if links != nil {
+            let stringAsData = text.data(using: .utf8)!
+            
+            var temporaryStringBytes = Data()
+            var temporaryGenericUseString = ""
+            
+            for i in 0..<(links!.count) {
+                if links![i].start == nil && links![i].end == nil {
+                    self.links![i].calculatedRange = (text as NSString).range(of: links![i].title)
+                } else {
+                    temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
+                    
+                    temporaryGenericUseString = String(data: temporaryStringBytes, encoding: .utf8)!
+                    
+                    self.links![i].calculatedRange = (text as NSString).range(of: temporaryGenericUseString)
+                }
+            }
+        }
     }
     
     public init(from decoder: Decoder) throws {
@@ -350,20 +369,22 @@ public struct Rant: Decodable, Identifiable, Hashable {
         isUserDPP = try? values.decode(Int.self, forKey: .isUserDPP)
         
         if links != nil {
-            let stringAsData = text.data(using: .utf8)!
+            //let stringAsData = text.data(using: .utf8)!
             
-            var temporaryStringBytes = Data()
-            var temporaryGenericUseString = ""
+            //var temporaryStringBytes = Data()
+            //var temporaryGenericUseString = ""
             
             for i in 0..<(links!.count) {
                 if links![i].start == nil && links![i].end == nil {
                     links![i].calculatedRange = (text as NSString).range(of: links![i].title)
                 } else {
-                    temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
+                    /*temporaryStringBytes = stringAsData[stringAsData.index(stringAsData.startIndex, offsetBy: links![i].start!)..<stringAsData.index(stringAsData.startIndex, offsetBy: links![i].end!)]
                     
                     temporaryGenericUseString = String(data: temporaryStringBytes, encoding: .utf8)!
                     
-                    links![i].calculatedRange = (text as NSString).range(of: temporaryGenericUseString)
+                    links![i].calculatedRange = (text as NSString).range(of: temporaryGenericUseString)*/
+                    
+                    links![i].calculatedRange = text.charRangeForByteRange(range: NSRange(location: links![i].start!, length: links![i].end! - links![i].start!))
                 }
             }
         }

--- a/Sources/SwiftRant/String+charRangeForByteRange.swift
+++ b/Sources/SwiftRant/String+charRangeForByteRange.swift
@@ -1,0 +1,34 @@
+//
+//  String+charRangeForByteRange.swift
+//  
+//
+//  Created by Omer Shamai on 04/01/2023.
+//
+
+import Foundation
+
+extension String {
+    func charRangeForByteRange(range: NSRange) -> NSRange {
+        let bytes = [UInt8](utf8)
+        
+        var charOffset = 0
+        
+        for i in 0..<range.location {
+            if (bytes[i] & 0xC0) != 0x80 {
+                charOffset += 1
+            }
+        }
+        
+        let location = charOffset
+        
+        for i in range.location..<(range.location + range.length) {
+            if (bytes[i] & 0xC0) != 0x80 {
+                charOffset += 1
+            }
+        }
+        
+        let length = charOffset - location
+        
+        return NSRange(location: location, length: length)
+    }
+}

--- a/Sources/SwiftRant/SwiftRant.swift
+++ b/Sources/SwiftRant/SwiftRant.swift
@@ -47,7 +47,18 @@ public struct SwiftRantError: SwiftRantErrorProtocol {
 }
 
 fileprivate struct CommentResponse: Decodable {
-    public let comment: Comment?
+    public var comment: Comment?
+    
+    enum CodingKeys: CodingKey {
+        case comment
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.comment = try container.decodeIfPresent(Comment.self, forKey: .comment)
+        
+        comment?.precalculateLinkRanges()
+    }
 }
 
 fileprivate struct ProfileResponse: Decodable {

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -207,7 +207,7 @@ final class SwiftRantTests: XCTestCase {
         dRAPI.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            dRAPI.getRantFromID(token: try! result.get(), id: 4831495, lastCommentID: nil) { result in
+            dRAPI.getRantFromID(token: try! result.get(), id: 6109206, lastCommentID: nil) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT")
@@ -313,7 +313,7 @@ final class SwiftRantTests: XCTestCase {
         drAPI.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            drAPI.getCommentFromID(6109454, token: try? result.get()) { result in
+            drAPI.getCommentFromID(6109441, token: try? result.get()) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")

--- a/Tests/SwiftRantTests/SwiftRantTests.swift
+++ b/Tests/SwiftRantTests/SwiftRantTests.swift
@@ -298,7 +298,9 @@ final class SwiftRantTests: XCTestCase {
     }
     
     func testComment() throws {
-        let keychainWrapper = KeychainWrapper(serviceName: "SwiftRant", accessGroup: "SwiftRantAccessGroup")
+        let drAPI = SwiftRant(shouldUseKeychainAndUserDefaults: false)
+        
+        //let keychainWrapper = KeychainWrapper(serviceName: "SwiftRant", accessGroup: "SwiftRantAccessGroup")
         
         let semaphore = DispatchSemaphore(value: 0)
         
@@ -308,10 +310,10 @@ final class SwiftRantTests: XCTestCase {
         print("Print your real password: ", terminator: "")
         let password = readLine()
         
-        SwiftRant.shared.logIn(username: username!, password: password!) { result in
+        drAPI.logIn(username: username!, password: password!) { result in
             XCTAssertNotNil(try? result.get())
             
-            SwiftRant.shared.getCommentFromID(4813564, token: nil) { result in
+            drAPI.getCommentFromID(6109454, token: try? result.get()) { result in
                 XCTAssertNotNil(try? result.get())
                 
                 print("BREAKPOINT HERE")
@@ -321,7 +323,7 @@ final class SwiftRantTests: XCTestCase {
         
         semaphore.wait()
         
-        let query: [String:Any] = [kSecClass as String: kSecClassGenericPassword,
+        /*let query: [String:Any] = [kSecClass as String: kSecClassGenericPassword,
                                    kSecMatchLimit as String: kSecMatchLimitOne,
                                    kSecReturnAttributes as String: true,
                                    kSecReturnData as String: true,
@@ -330,7 +332,7 @@ final class SwiftRantTests: XCTestCase {
         
         keychainWrapper.removeAllKeys()
         UserDefaults.resetStandardUserDefaults()
-        SecItemDelete(query as CFDictionary)
+        SecItemDelete(query as CFDictionary)*/
     }
     
     func testVoteOnRant() throws {


### PR DESCRIPTION
This is a fix for #28.

The issue was that if you have multiple links with the same shortened versions, the calculator would always pick the first link with the specified shortened version.

This new and improved version **directly converts** the original byte ranges retrieved from the ranges and converts them to a working character-based NSRange and thus generate a fully working and functional link range.